### PR TITLE
fix(security): upgrade certbot dependencies to fix critical and high CVEs

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -72,7 +72,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: '${{ matrix.image }}:scan'
           format: 'sarif'
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run Trivy (table output for PR comments)
         if: github.event_name == 'pull_request'
-        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: '${{ matrix.image }}:scan'
           format: 'table'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Trivy vulnerability scanner (config mode)
-        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           scan-type: 'config'
           scan-ref: '.'
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Trivy vulnerability scanner (fs mode)
-        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/certbot/Dockerfile
+++ b/certbot/Dockerfile
@@ -23,12 +23,19 @@ LABEL org.opencontainers.image.title="VNtyper Certbot" \
 
 # Upgrade base packages and pip for security fixes
 # - CVE-2024-58251, CVE-2025-46394: busybox vulnerabilities
+# - CVE-2025-6965: sqlite integer truncation (fixed via apk upgrade)
 # - CVE-2025-8869: pip symbolic link extraction vulnerability
 # - CVE-2025-66418, CVE-2025-66471: urllib3 decompression vulnerabilities
+# - CVE-2026-26007: cryptography subgroup attack on SECT curves
+# - CVE-2026-24049: wheel privilege escalation via malicious wheel files
+# - CVE-2026-23949: jaraco.context path traversal via malicious tar archives
 # hadolint ignore=DL3013
 RUN apk upgrade --no-cache \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir "urllib3>=2.6.0" \
+    && pip install --no-cache-dir "cryptography>=46.0.5" \
+    && pip install --no-cache-dir "wheel>=0.46.2" \
+    && pip install --no-cache-dir "jaraco.context>=6.1.0" \
     && pip uninstall -y uv 2>/dev/null || true
 
 # Create non-root user for certbot operations


### PR DESCRIPTION
## Summary

Fixes 5 Trivy code scanning alerts (#101, #102, #64, #63, #62) by upgrading vulnerable Python packages in the certbot container:

- **cryptography >= 46.0.5** — fixes CVE-2026-26007 (High): subgroup attack due to missing validation for SECT curves
- **wheel >= 0.46.2** — fixes CVE-2026-24049 (High): privilege escalation via malicious wheel file unpacking
- **jaraco.context >= 6.1.0** — fixes CVE-2026-23949 (High): path traversal via malicious tar archives
- **sqlite** (CVE-2025-6965, Critical): already covered by existing `apk upgrade --no-cache`; documented in comments

## Test plan

- [ ] CI passes (hadolint, Trivy scans, container build)
- [ ] Certbot container builds successfully with upgraded packages
- [ ] Trivy alerts #101, #102, #64, #63, #62 resolve after merge