### PR TITLE
build(deps): dependency sweep + certbot CVE patches (closes 7 Dependabot PRs, 6 security alerts)

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -57,10 +57,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build ${{ matrix.image }} image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -84,7 +84,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v3
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v3
         with:
           sarif_file: 'trivy-${{ matrix.image }}-results.sarif'
           category: 'container-${{ matrix.image }}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run actionlint
-        uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518 # v2.0.0
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.0.0
         with:
           fail-on-error: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,7 +56,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v3
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v3
         with:
           sarif_file: 'trivy-config-results.sarif'
           category: 'trivy-config'
@@ -108,7 +108,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy FS results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v3
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v3
         with:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-filesystem'

--- a/certbot/Dockerfile
+++ b/certbot/Dockerfile
@@ -10,8 +10,8 @@
 # =============================================================================
 
 # Pin base image with version and digest for supply chain security
-# certbot/certbot:v3.0.1
-FROM certbot/certbot:v5.3.1@sha256:8be9c9f10232e223acd84acdacc26858fcd46e8194c6dcdf99b2ddd231a362fe
+# certbot/certbot:v5.6.0
+FROM certbot/certbot:v5.6.0@sha256:0107d084c225631fc64a8313e19adb07275f7296fde338f7dfa93986c80b2e3e
 
 # OCI Labels for image metadata and traceability
 LABEL org.opencontainers.image.title="VNtyper Certbot" \
@@ -25,17 +25,27 @@ LABEL org.opencontainers.image.title="VNtyper Certbot" \
 # - CVE-2024-58251, CVE-2025-46394: busybox vulnerabilities
 # - CVE-2025-6965: sqlite integer truncation (fixed via apk upgrade)
 # - CVE-2025-8869: pip symbolic link extraction vulnerability
-# - CVE-2025-66418, CVE-2025-66471: urllib3 decompression vulnerabilities
+# - CVE-2026-44432, CVE-2026-44431: urllib3 streaming decompression bomb and
+#   cross-origin redirect header leak (fixed in 2.7.0)
 # - CVE-2026-26007: cryptography subgroup attack on SECT curves
 # - CVE-2026-24049: wheel privilege escalation via malicious wheel files
 # - CVE-2026-23949: jaraco.context path traversal via malicious tar archives
+# - CVE-2026-27459, CVE-2026-27448: pyOpenSSL DTLS cookie callback buffer
+#   overflow and TLS servername callback bypass (fixed in 26.0.0)
+# - CVE-2026-45409: idna idna.encode() bypass of the CVE-2024-3651
+#   quadratic-complexity fix (fixed in 3.15)
+# - CVE-2026-25645: requests predictable temp file in extract_zipped_paths()
+#   (fixed in 2.33.0)
 # hadolint ignore=DL3013
 RUN apk upgrade --no-cache \
     && pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir "urllib3>=2.6.0" \
+    && pip install --no-cache-dir "urllib3>=2.7.0" \
     && pip install --no-cache-dir "cryptography>=46.0.5" \
     && pip install --no-cache-dir "wheel>=0.46.2" \
     && pip install --no-cache-dir "jaraco.context>=6.1.0" \
+    && pip install --no-cache-dir "pyOpenSSL>=26.0.0" \
+    && pip install --no-cache-dir "idna>=3.15" \
+    && pip install --no-cache-dir "requests>=2.33.0" \
     && pip uninstall -y uv 2>/dev/null || true
 
 # Create non-root user for certbot operations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Redis - In-memory data store for Celery broker and caching
   # ===========================================================================
   redis:
-    image: redis:8-alpine@sha256:2afba59292f25f5d1af200496db41bea2c6c816b059f57ae74703a50a03a27d0
+    image: redis:8-alpine@sha256:81b6f81d6a6c5b9019231a2e8eb10085e3a139a34f833dcc965a8a959b040b72
     container_name: vntyper_online_redis
     # Run as redis user (uid 999 in alpine) to avoid chown issues with read_only
     user: "999:999"

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -10,8 +10,8 @@
 # =============================================================================
 
 # Pin base image with digest for supply chain security
-# nginxinc/nginx-unprivileged:1.27.3-alpine-slim
-FROM nginxinc/nginx-unprivileged:1.29.5-alpine-slim@sha256:800307aaf07c143f5d90aa9d4269cc1971dcfe5aee7cabd11579ac4c6bcf198f
+# nginxinc/nginx-unprivileged:1.31.1-alpine-slim
+FROM nginxinc/nginx-unprivileged:1.31.1-alpine-slim@sha256:0a5b08a6a5f546f4ed70c1c45815e9be1ba23daf8c5bfdfdd63cc7c341c2e4dd
 
 # OCI Labels for image metadata and traceability
 LABEL org.opencontainers.image.title="VNtyper Proxy" \


### PR DESCRIPTION
Consolidates the 7 open Dependabot PRs and resolves all 6 open Trivy code-scanning alerts in a single reviewed change.

## Dependency bumps (Dependabot)

| PR | Update | File |
|----|--------|------|
| #69 | nginx-unprivileged `1.29.5` → `1.31.1`-alpine-slim | `proxy/Dockerfile` |
| #67 | certbot `v5.3.1` → `v5.6.0` | `certbot/Dockerfile` |
| #64 | redis `8-alpine` digest refresh | `docker-compose.yml` |
| #63 | github-actions-minor group: `codeql-action/upload-sarif` (×3), `raven-actions/actionlint` | workflows |
| #59 | `docker/setup-buildx-action` `3.12.0` → `4.0.0` | `container-scan.yml` |
| #58 | `docker/build-push-action` `6.19.2` → `7.0.0` | `container-scan.yml` |
| #62 | backend submodule `d408d6d` → `9643104` | **already superseded** — submodule is at `c5a58f1` (descendant of the target), so no change needed |

All actions stay pinned to full commit SHAs with version comments.

## Security alerts (Trivy, certbot image)

The certbot image is the only Python-based image scanned, so all 6 alerts live there. Fixed by extending the existing pip-upgrade pattern in `certbot/Dockerfile`:

| Alert | Package | Fix | Severity |
|-------|---------|-----|----------|
| #134 | urllib3 (CVE-2026-44432, decompression bomb) | `>=2.7.0` | High |
| #133 | urllib3 (CVE-2026-44431, cross-origin header leak) | `>=2.7.0` | Medium |
| #105 | pyOpenSSL (CVE-2026-27459, DTLS cookie buffer overflow) | `>=26.0.0` | High |
| #106 | pyOpenSSL (CVE-2026-27448, TLS servername callback bypass) | `>=26.0.0` | Low |
| #137 | idna (CVE-2026-45409, `idna.encode()` bypass of CVE-2024-3651) | `>=3.15` | Medium |
| #107 | requests (CVE-2026-25645, predictable temp file) | `>=2.33.0` | Medium |

## Verification

- `hadolint` (repo `.hadolint.yaml`) — clean on both Dockerfiles
- `yamllint`, `actionlint` — pass on all touched workflows
- `docker compose -f docker-compose.yml config` — valid

## Notes

- This branch also carries the earlier frontend submodule sync (commit `e90f63f`).
- On merge, Dependabot will auto-close #69, #67, #64, #63, #59, #58; #62 can be closed as superseded.
