### PR TITLE
docs: shorten the documented result retention to 3 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,14 @@ Create and configure the `.env.production` file with your production settings. *
         # Celery Configuration
         CELERY_BROKER_URL=redis://redis:6379/0
         CELERY_RESULT_BACKEND=redis://redis:6379/0
-        MAX_RESULT_AGE_DAYS=7
+        # How long a completed job's result archive stays retrievable, in days.
+        # /download/{job_id}/ is an unauthenticated capability URL, so this value is
+        # the exposure window for a completed job. Keep it as short as collection
+        # allows: `vntyper online` polls for at most 4 hours and the completion email
+        # states no deadline, so the binding case is a person reading that email
+        # later -- 3 days covers submit-Friday, download-Monday.
+        # This file overrides the image default, so it is the value that governs.
+        MAX_RESULT_AGE_DAYS=3
 
         # Application Paths
         INPUT_VOLUME=/directory/out/download


### PR DESCRIPTION
`/download/{job_id}/` requires no credential, so `MAX_RESULT_AGE_DAYS` **is** the exposure
window for a completed job: the id is the capability. This mitigates
[hassansaei/VNtyper#189](https://github.com/hassansaei/VNtyper/issues/189) by reducing
exposure *duration*. It does **not** fix it — the capability-URL design is untouched.

## Why this repo's change is the one that matters operationally

The compose stack loads `env_file: ${ENV_FILE:-.env.local}`, which is **untracked and
server-side**. Whatever an operator sets there wins over the image default, so
[hassansaei/VNtyper#256](https://github.com/hassansaei/VNtyper/pull/256) — which changes
`docker/app/config.py` and `docker-compose.yml` — **may not move production on its own.**

**Action required beyond merging this:** someone has to update the deployed `.env.local`.
This PR only changes the instruction operators follow when setting one up.

## Where the number came from

`vntyper online` polls for at most **4 hours** (`DEFAULT_POLL_TIMEOUT_SECONDS`) and then
gives up, and the completion email stated **no deadline at all**. So the CLI path never needs
days; the binding case is a person opening that email later. **3 days covers
submit-Friday-evening → download-Monday-morning** and cuts the window by 57%.

## Ordering

Three repositories, three PRs. VNtyper's lands first because it is what the image is built
from. The **frontend** PR
([berntpopp/vntyper-online-frontend](https://github.com/berntpopp/vntyper-online-frontend))
states the number publicly and should not lag behind the service: a site promising 7 days
while the service keeps 3 sends users back on day 5 to find their results gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YU5VCyuqN9at47bFBfxJP